### PR TITLE
Use version of puphpet/debian75-x64 with supported Puppet

### DIFF
--- a/graylog/Vagrantfile
+++ b/graylog/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "puphpet/debian75-x64"
+  config.vm.box_version = "2.0"
 
   config.vm.provider "virtualbox" do |v|
     v.name = 'SuaaS log server'


### PR DESCRIPTION
With the most recent version of this box (v20151201), Puppet receives a command-line option it no longer supports:

    ==> default: Error: Could not parse application options: invalid option: --manifestdir
    The SSH command responded with a non-zero exit status. Vagrant
    assumes that this means the command failed. The output for this command
    should be in the log above. Please read the output to determine what
    went wrong.