### PR TITLE
Remove unneeded ntp installation for debian

### DIFF
--- a/provisioning/ansible/roles/common/tasks/main.yml
+++ b/provisioning/ansible/roles/common/tasks/main.yml
@@ -23,8 +23,3 @@
   yum: name=ntp state=present
   notify: start ntp
   when: ansible_os_family == "RedHat"
-
-- name: Install ntp
-  apt: name=ntp state=present
-  notify: start ntp
-  when: ansible_os_family == "Debian"


### PR DESCRIPTION
We are using RHEL/CentOS, so a Debian specific installation is not necessary.